### PR TITLE
feat: update index and beta pages

### DIFF
--- a/BETA.md
+++ b/BETA.md
@@ -1,111 +1,165 @@
 ---
 layout: default
-title: Fasten BETA Instructions
+title: Getting started
+description: "Getting started with the Fasten Beta"
+nav_order: 1
 ---
 
-# Fasten BETA Instructions
+# Welcome to the Fasten Beta
 
-Welcome to the Fasten Beta!
-
-If you haven't already, please fill out this [Google Form](https://forms.gle/SNsYX9BNMXB6TuTw6)
-
-## Getting Started
-
-This Beta is provided with a couple of caveats:
+Welcome to the Fasten beta! This beta is provided with a couple of caveats:
 
 - Fasten is still partially closed-source (please see the Reddit discussion for more info)
 - The Beta version is only available as a Docker image (eventually we'll support other modes of distribution)
 - Fasten is still a work-in-progress (many buttons in the UI do not do anything)
 
-## Instructions
+If you haven't already, please fill out this [Google Form](https://forms.gle/SNsYX9BNMXB6TuTw6)
 
-There are 2 flavors of Fasten:
-- `sandbox` - This version only allows you to connect to a handful of Healthcare providers, using Sandbox accounts that are meant for testing, and contain synthetic(fake) data to give you an idea what Fasten will look like, without requiring personal medical information.
-- `main` - This version allows you to connect to 650+ different Healthcare providers, using your existing accounts. It will allow you to connect and retrive your full electronic medical record and store it within Fasten. 
+## Getting Started
+
+Fasten comes in two flavors depending on whether you want to use it with your real medical records, or just test it out with fake data.
+
+{: .fs-6 .fw-300 }
+
+How would you like to use Fasten?
+
+[With real medical records](#setting-up-fasten-to-use-with-real-medical-data-main){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[With fake test data](#setting-up-fasten-to-use-fake-test-data-sandbox){: .btn .fs-5 .mb-4 .mb-md-0 }
+
+---
+
+### Setting up Fasten to use with real medical data (Main)
+
+This version allows you to connect to 650+ different Healthcare providers, using your existing accounts. It will allow you to connect and retrive your full electronic medical record and store it within Fasten.
 
 Run the following commands to download and start the Fasten docker container.
 
-> The instructions below are for the `sandbox` flavor of Fasten. If you'd like to connect using your real account, please use `ghcr.io/fastenhealth/fasten-onprem:main` in the commands below.
-
 ```
-docker pull ghcr.io/fastenhealth/fasten-onprem:sandbox 
-docker run --rm -p 9090:8080 ghcr.io/fastenhealth/fasten-onprem:sandbox 
+docker pull ghcr.io/fastenhealth/fasten-onprem:main
+docker run --rm -p 9090:8080 ghcr.io/fastenhealth/fasten-onprem:main
 ```
 
+Next, open a browser to [http://localhost:9090](http://localhost:9090)
 
-Next, open a browser to http://localhost:9090
+At this point you'll be redirected to the login page.
 
-At this point you'll be redirected to the login page. 
+#### Logging In
 
-### Logging In
-
-Before you can use the Fasten BETA you'll need to [Create an Account](http://localhost:9090/web/auth/signup).
+Once you've been redirected to the login page, you'll need to create an account at [http://localhost:9090/web/auth/signup](http://localhost:9090/web/auth/signup).
 
 It can be as simple as
+
 - **Username:** `testuser`
 - **Password:** `testtest`
 
-> See `Connecting a new Source` below for credentials you can use to connect to healthcare providers. 
+Congrats! You're now logged in. You'll be redirected to the dashboard, which will be empty until you connect a healthcare provider.
 
-### Dashboard
+#### Dashboard
 
-Once you login, you'll be taken to the dashboard. 
+Once you login, you'll be taken to the dashboard.
 From here you can explore the data retrieved from the various healthcare providers.
-This page will intially be empty, see the next section - `Connecting a new Source`  - for more info.
+This page will intially be empty, see the next section - `Connecting a new Source` - for more info.
 
+#### Connecting a new Source
 
-### Connecting a new Source
 Before you can use Fasten, you'll need to connect a healthcare provider.
 
-#### Production (Main) Flavor
+If you're using the `main` flavor of Fasten, find a Source where you have an account, and login with your credentials.
 
-If you're using the `main` flavor of Fasten, find a Source where you have an account, and login with your credentials. 
+Congrats, you're all set! Fasten will now start syncing your medical records.
 
-#### Sandbox Flavor
+---
+
+### Setting up Fasten to use fake test data (Sandbox)
+
+{: .warning }
+
+> The instructions below are for the `sandbox` flavor of Fasten. If you'd like to connect using your real account, please follow the instructions [here](#setting-up-fasten-main).
 
 This version only allows you to connect to a handful of Healthcare providers, using Sandbox accounts that are meant for testing, and contain synthetic(fake) data to give you an idea what Fasten will look like, without requiring personal medical information.
 
-To do so, you'll need to use a Sandbox user and password from the table below. You should not (and cannot) use real credentials with the Sandbox version of Fasten. 
+Run the following commands to download and start the Fasten docker container.
 
-| Source                | Credentials | Link |
-|-----------------------| --- | ---  | 
-| Aetna                 | Username: `aetnaTestUser3` <br>Password: `FHIRdemo2020` | |
-| AllScripts            | Username: `alice.newman@sunrise184region.com` <br>Password: `Allscripts#1` | [test accounts](https://developer.allscripts.com/Content/fhir/FHIRSandboxes_index.html)
-| AthenaHealth          | Username: `phrtest_preview@mailinator.com` <br>Password: `Password1` | [test accounts](https://docs.athenahealth.com/api/guides/onboarding-overview)
-| CareEvolution         | Username: `CEPatient` <br>Password: `CEPatient2018` | [test accounts](https://fhir.careevolution.com/TestPatientAccounts.html) |
-| Cerner                | Username: `nancysmart` <br>Password: `Cerner01` | [test accounts](https://docs.google.com/document/d/10RnVyF1etl_17pyCyK96tyhUWRbrTyEcqpwzW-Z-Ybs/edit)|
-| Cigna                 | Username: `syntheticuser05` <br>Password: `5ynthU5er5` | [test accounts](https://developer.cigna.com/service-apis/patient-access/sandbox#How-to-Use-the-Sandbox-Sandbox-Test-Users) |
-| eClinicalWorks/Healow | Username: `AdultFemaleFHIR` <br>Password: `e@CWFHIR1` | [test accounts](https://fhir.eclinicalworks.com/ecwopendev/)|
-| Epic                  | Username: `fhircamila` <br>Password: `epicepic1` | [test accounts](https://fhir.epic.com/Documentation?docId=testpatients)|
-| HealthIT              | Username: `demouser` <br>Password: `Demouser1!` | [test accounts](https://fhirsandbox.healthit.gov/secure/r4/view/userlogin.html)|
-| Humana              | Username: `HUser00007` <br>Password: `PW00007!` | [test accounts](https://developers.humana.com/apis/oauth)|
-| Kaiser                | Username: <br>Password: | |
-| Logica                | Username: <br>Password: | |
-| Medicare              | Username: `BBUser00000` <br>Password: `PW00000!` | [test accounts](https://bluebutton.cms.gov/developers/#developer-guidelines) |
-| Meditech              | Username: <br>Password: | |
-| NextGen               | Username: `patientapitest` <br>Password: `Password1!` | [test accounts](https://www.nextgen.com/-/media/files/api/nge-patient-api-auth-guide.pdf)|
-| VA Health             | Username: `va.api.user+idme.101@gmail.com` <br>Password: `Password1234!` | [test accounts](https://github.com/department-of-veterans-affairs/vets-api-clients/blob/master/test_accounts/health_test_accounts.md)|
+| Source                | Credentials                                                                | Link                                                                                                                                  |
+| --------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Aetna                 | Username: `aetnaTestUser3` <br>Password: `FHIRdemo2020`                    |                                                                                                                                       |
+| AllScripts            | Username: `alice.newman@sunrise184region.com` <br>Password: `Allscripts#1` | [test accounts](https://developer.allscripts.com/Content/fhir/FHIRSandboxes_index.html)                                               |
+| AthenaHealth          | Username: `phrtest_preview@mailinator.com` <br>Password: `Password1`       | [test accounts](https://docs.athenahealth.com/api/guides/onboarding-overview)                                                         |
+| CareEvolution         | Username: `CEPatient` <br>Password: `CEPatient2018`                        | [test accounts](https://fhir.careevolution.com/TestPatientAccounts.html)                                                              |
+| Cerner                | Username: `nancysmart` <br>Password: `Cerner01`                            | [test accounts](https://docs.google.com/document/d/10RnVyF1etl_17pyCyK96tyhUWRbrTyEcqpwzW-Z-Ybs/edit)                                 |
+| Cigna                 | Username: `syntheticuser05` <br>Password: `5ynthU5er5`                     | [test accounts](https://developer.cigna.com/service-apis/patient-access/sandbox#How-to-Use-the-Sandbox-Sandbox-Test-Users)            |
+| eClinicalWorks/Healow | Username: `AdultFemaleFHIR` <br>Password: `e@CWFHIR1`                      | [test accounts](https://fhir.eclinicalworks.com/ecwopendev/)                                                                          |
+| Epic                  | Username: `fhircamila` <br>Password: `epicepic1`                           | [test accounts](https://fhir.epic.com/Documentation?docId=testpatients)                                                               |
+| HealthIT              | Username: `demouser` <br>Password: `Demouser1!`                            | [test accounts](https://fhirsandbox.healthit.gov/secure/r4/view/userlogin.html)                                                       |
+| Humana                | Username: `HUser00007` <br>Password: `PW00007!`                            | [test accounts](https://developers.humana.com/apis/oauth)                                                                             |
+| Kaiser                | Username: <br>Password:                                                    |                                                                                                                                       |
+| Logica                | Username: <br>Password:                                                    |                                                                                                                                       |
+| Medicare              | Username: `BBUser00000` <br>Password: `PW00000!`                           | [test accounts](https://bluebutton.cms.gov/developers/#developer-guidelines)                                                          |
+| Meditech              | Username: <br>Password:                                                    |                                                                                                                                       |
+| NextGen               | Username: `patientapitest` <br>Password: `Password1!`                      | [test accounts](https://www.nextgen.com/-/media/files/api/nge-patient-api-auth-guide.pdf)                                             |
+| VA Health             | Username: `va.api.user+idme.101@gmail.com` <br>Password: `Password1234!`   | [test accounts](https://github.com/department-of-veterans-affairs/vets-api-clients/blob/master/test_accounts/health_test_accounts.md) |
 
-Some providers (such as Cerner) may take a long time to sync, as their sandbox accounts have lots of test data. Please be patient. 
+Next, open a browser to [http://localhost:9090](http://localhost:9090)
 
-### Testing Manual Bundle Upload
+At this point you'll be redirected to the login page.
 
+#### Logging In
 
+Once you've been redirected to the login page, you'll need to create an account at [http://localhost:9090/web/auth/signup](http://localhost:9090/web/auth/signup).
 
-If you'd like to test the manual bundle upload, you can use data provided by the [Synthea](https://synthetichealth.github.io/synthea-sample-data/downloads/synthea_sample_data_fhir_r4_sep2019.zip) project to test. 
-Just extract the downloaded `zip` file, and upload one of the many `json`  files. 
+It can be as simple as
 
+- **Username:** `testuser`
+- **Password:** `testtest`
+
+Congrats! You're now logged in. You'll be redirected to the dashboard, which will be empty until you connect a healthcare provider.
+
+#### Dashboard
+
+Once you login, you'll be taken to the dashboard.
+From here you can explore the data retrieved from the various healthcare providers.
+This page will intially be empty, see the next section - `Connecting a new Source` - for more info.
+
+#### Connecting a new Source
+
+Before you can use Fasten, you'll need to connect a healthcare provider.
+
+This version only allows you to connect to a handful of Healthcare providers, using Sandbox accounts that are meant for testing, and contain synthetic(fake) data to give you an idea what Fasten will look like, without requiring personal medical information.
+
+To do so, you'll need to use a Sandbox user and password from the table below. You should not (and cannot) use real credentials with the Sandbox version of Fasten.
+
+| Source                | Credentials                                                                | Link                                                                                                                                  |
+| --------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Aetna                 | Username: `aetnaTestUser3` <br>Password: `FHIRdemo2020`                    |                                                                                                                                       |
+| AllScripts            | Username: `alice.newman@sunrise184region.com` <br>Password: `Allscripts#1` | [test accounts](https://developer.allscripts.com/Content/fhir/FHIRSandboxes_index.html)                                               |
+| AthenaHealth          | Username: `phrtest_preview@mailinator.com` <br>Password: `Password1`       | [test accounts](https://docs.athenahealth.com/api/guides/onboarding-overview)                                                         |
+| CareEvolution         | Username: `CEPatient` <br>Password: `CEPatient2018`                        | [test accounts](https://fhir.careevolution.com/TestPatientAccounts.html)                                                              |
+| Cerner                | Username: `nancysmart` <br>Password: `Cerner01`                            | [test accounts](https://docs.google.com/document/d/10RnVyF1etl_17pyCyK96tyhUWRbrTyEcqpwzW-Z-Ybs/edit)                                 |
+| Cigna                 | Username: `syntheticuser05` <br>Password: `5ynthU5er5`                     | [test accounts](https://developer.cigna.com/service-apis/patient-access/sandbox#How-to-Use-the-Sandbox-Sandbox-Test-Users)            |
+| eClinicalWorks/Healow | Username: `AdultFemaleFHIR` <br>Password: `e@CWFHIR1`                      | [test accounts](https://fhir.eclinicalworks.com/ecwopendev/)                                                                          |
+| Epic                  | Username: `fhircamila` <br>Password: `epicepic1`                           | [test accounts](https://fhir.epic.com/Documentation?docId=testpatients)                                                               |
+| HealthIT              | Username: `demouser` <br>Password: `Demouser1!`                            | [test accounts](https://fhirsandbox.healthit.gov/secure/r4/view/userlogin.html)                                                       |
+| Kaiser                | Username: <br>Password:                                                    |                                                                                                                                       |
+| Logica                | Username: <br>Password:                                                    |                                                                                                                                       |
+| Medicare              | Username: `BBUser00000` <br>Password: `PW00000!`                           | [test accounts](https://bluebutton.cms.gov/developers/#developer-guidelines)                                                          |
+| Meditech              | Username: <br>Password:                                                    |                                                                                                                                       |
+| NextGen               | Username: `patientapitest` <br>Password: `Password1!`                      | [test accounts](https://www.nextgen.com/-/media/files/api/nge-patient-api-auth-guide.pdf)                                             |
+| VA Health             | Username: `va.api.user+idme.101@gmail.com` <br>Password: `Password1234!`   | [test accounts](https://github.com/department-of-veterans-affairs/vets-api-clients/blob/master/test_accounts/health_test_accounts.md) |
+
+Some providers (such as Cerner) may take a long time to sync, as their sandbox accounts have lots of test data. Please be patient.
+
+#### Testing Manual Bundle Upload
+
+If you'd like to test the manual bundle upload, you can use data provided by the [Synthea](https://synthetichealth.github.io/synthea-sample-data/downloads/synthea_sample_data_fhir_r4_sep2019.zip) project to test.
+Just extract the downloaded `zip` file, and upload one of the many `json` files.
+
+---
 
 ## Feedback
 
-If you notice any (non-obvious) issues with Fasten, please feel free to open an issue on Github. 
-If you have any ideas or feedback for how to make Fasten better, please also consider opening an issue on Github. 
-
-https://github.com/fastenhealth/docs/issues
+If you notice any (non-obvious) issues with Fasten, please feel free to [open an issue on Github](https://github.com/fastenhealth/docs/issues).
+If you have any ideas or feedback for how to make Fasten better, please also consider [opening an issue on Github](https://github.com/fastenhealth/docs/issues).
 
 ### Discord
-Please consider joining the Fasten Discord as well. I'll be keeping an eye on it, and answering questions as they come up.
 
-https://discord.gg/Bykz6BAN8p
-
-
+Please consider joining the [Fasten Discord](https://discord.gg/Bykz6BAN8p) as well. I'll be keeping an eye on it, and answering questions as they come up.

--- a/BETA.md
+++ b/BETA.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Getting started
-description: "Getting started with the Fasten Beta"
+description: "Getting started with self-hosting the Fasten Beta"
 nav_order: 1
 ---
 
@@ -17,18 +17,20 @@ If you haven't already, please fill out this [Google Form](https://forms.gle/SNs
 
 ## Getting Started
 
+Below are instructions to get started with self hosting the Fasten Beta.
+
 Fasten comes in two flavors depending on whether you want to use it with your real medical records, or just test it out with fake data.
 
 {: .fs-6 .fw-300 }
 
 How would you like to use Fasten?
 
-[With real medical records](#setting-up-fasten-to-use-with-real-medical-data-main){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[With real medical records](#setting-up-fasten-to-use-with-real-medical-data){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [With fake test data](#setting-up-fasten-to-use-fake-test-data-sandbox){: .btn .fs-5 .mb-4 .mb-md-0 }
 
 ---
 
-### Setting up Fasten to use with real medical data (Main)
+### Setting up Fasten to use with real medical data
 
 This version allows you to connect to 650+ different Healthcare providers, using your existing accounts. It will allow you to connect and retrive your full electronic medical record and store it within Fasten.
 
@@ -74,7 +76,7 @@ Congrats, you're all set! Fasten will now start syncing your medical records.
 
 {: .warning }
 
-> The instructions below are for the `sandbox` flavor of Fasten. If you'd like to connect using your real account, please follow the instructions [here](#setting-up-fasten-main).
+> The instructions below are for the `sandbox` flavor of Fasten, which cannot connect to real patient portals. If you'd like to use Fasten with your real healthcare accounts, please follow the instructions [here](#setting-up-fasten-main).
 
 This version only allows you to connect to a handful of Healthcare providers, using Sandbox accounts that are meant for testing, and contain synthetic(fake) data to give you an idea what Fasten will look like, without requiring personal medical information.
 

--- a/BETA.md
+++ b/BETA.md
@@ -82,25 +82,6 @@ This version only allows you to connect to a handful of Healthcare providers, us
 
 Run the following commands to download and start the Fasten docker container.
 
-| Source                | Credentials                                                                | Link                                                                                                                                  |
-| --------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| Aetna                 | Username: `aetnaTestUser3` <br>Password: `FHIRdemo2020`                    |                                                                                                                                       |
-| AllScripts            | Username: `alice.newman@sunrise184region.com` <br>Password: `Allscripts#1` | [test accounts](https://developer.allscripts.com/Content/fhir/FHIRSandboxes_index.html)                                               |
-| AthenaHealth          | Username: `phrtest_preview@mailinator.com` <br>Password: `Password1`       | [test accounts](https://docs.athenahealth.com/api/guides/onboarding-overview)                                                         |
-| CareEvolution         | Username: `CEPatient` <br>Password: `CEPatient2018`                        | [test accounts](https://fhir.careevolution.com/TestPatientAccounts.html)                                                              |
-| Cerner                | Username: `nancysmart` <br>Password: `Cerner01`                            | [test accounts](https://docs.google.com/document/d/10RnVyF1etl_17pyCyK96tyhUWRbrTyEcqpwzW-Z-Ybs/edit)                                 |
-| Cigna                 | Username: `syntheticuser05` <br>Password: `5ynthU5er5`                     | [test accounts](https://developer.cigna.com/service-apis/patient-access/sandbox#How-to-Use-the-Sandbox-Sandbox-Test-Users)            |
-| eClinicalWorks/Healow | Username: `AdultFemaleFHIR` <br>Password: `e@CWFHIR1`                      | [test accounts](https://fhir.eclinicalworks.com/ecwopendev/)                                                                          |
-| Epic                  | Username: `fhircamila` <br>Password: `epicepic1`                           | [test accounts](https://fhir.epic.com/Documentation?docId=testpatients)                                                               |
-| HealthIT              | Username: `demouser` <br>Password: `Demouser1!`                            | [test accounts](https://fhirsandbox.healthit.gov/secure/r4/view/userlogin.html)                                                       |
-| Humana                | Username: `HUser00007` <br>Password: `PW00007!`                            | [test accounts](https://developers.humana.com/apis/oauth)                                                                             |
-| Kaiser                | Username: <br>Password:                                                    |                                                                                                                                       |
-| Logica                | Username: <br>Password:                                                    |                                                                                                                                       |
-| Medicare              | Username: `BBUser00000` <br>Password: `PW00000!`                           | [test accounts](https://bluebutton.cms.gov/developers/#developer-guidelines)                                                          |
-| Meditech              | Username: <br>Password:                                                    |                                                                                                                                       |
-| NextGen               | Username: `patientapitest` <br>Password: `Password1!`                      | [test accounts](https://www.nextgen.com/-/media/files/api/nge-patient-api-auth-guide.pdf)                                             |
-| VA Health             | Username: `va.api.user+idme.101@gmail.com` <br>Password: `Password1234!`   | [test accounts](https://github.com/department-of-veterans-affairs/vets-api-clients/blob/master/test_accounts/health_test_accounts.md) |
-
 Next, open a browser to [http://localhost:9090](http://localhost:9090)
 
 At this point you'll be redirected to the login page.

--- a/beta/index.md
+++ b/beta/index.md
@@ -11,16 +11,16 @@ has_children: true
 Welcome to the Fasten beta! This beta is provided with a couple of caveats:
 
 - Fasten is still partially closed-source (please see the Reddit discussion for more info)
-- The Beta version is only available as a Docker image (eventually we'll support other modes of distribution)
+- The beta version is only available as a Docker image (eventually we'll support other modes of distribution)
 - Fasten is still a work-in-progress (many buttons in the UI do not do anything)
 
-If you haven't already, please fill out this [Google Form](https://forms.gle/SNsYX9BNMXB6TuTw6)
+If you would like to stay up-to-date with the latest updates, please fill out this [Google Form](https://forms.gle/SNsYX9BNMXB6TuTw6)
 
 ---
 
 ## Getting Started
 
-Below are instructions to get started with self hosting the Fasten Beta.
+Below are instructions to get started with self hosting the Fasten beta.
 
 Fasten comes in two flavors depending on whether you want to use it with your real medical records, or just test it out with fake data.
 

--- a/beta/index.md
+++ b/beta/index.md
@@ -1,0 +1,41 @@
+---
+layout: default
+title: Getting started
+description: "Getting started with self-hosting the Fasten Beta"
+nav_order: 1
+has_children: true
+---
+
+# Welcome to the Fasten Beta
+
+Welcome to the Fasten beta! This beta is provided with a couple of caveats:
+
+- Fasten is still partially closed-source (please see the Reddit discussion for more info)
+- The Beta version is only available as a Docker image (eventually we'll support other modes of distribution)
+- Fasten is still a work-in-progress (many buttons in the UI do not do anything)
+
+If you haven't already, please fill out this [Google Form](https://forms.gle/SNsYX9BNMXB6TuTw6)
+
+---
+
+## Getting Started
+
+Below are instructions to get started with self hosting the Fasten Beta.
+
+Fasten comes in two flavors depending on whether you want to use it with your real medical records, or just test it out with fake data.
+
+## How would you like to use Fasten?
+
+[With real medical records](/beta/main.html){: .btn .btn-primary .fs-5 .mb-4 .mt-4 .mb-md-0 .mr-2 }
+[With fake test data](/beta/sandbox.html){: .btn .fs-5 .mb-4 .mt-4 .mb-md-0 }
+
+---
+
+## Feedback
+
+If you notice any (non-obvious) issues with Fasten, please feel free to [open an issue on Github](https://github.com/fastenhealth/docs/issues).
+If you have any ideas or feedback for how to make Fasten better, please also consider [opening an issue on Github](https://github.com/fastenhealth/docs/issues).
+
+### Discord
+
+Please consider joining the [Fasten Discord](https://discord.gg/Bykz6BAN8p) as well. I'll be keeping an eye on it, and answering questions as they come up.

--- a/beta/main.md
+++ b/beta/main.md
@@ -1,0 +1,47 @@
+---
+layout: default
+title: Setting up Fasten to Use With Real Medical Data
+parent: Getting started
+description: "Setting up Fasten to use with real medical data"
+nav_order: 1
+---
+
+# Setting up Fasten to Use With Real Medical Data
+
+This version allows you to connect to 650+ different Healthcare providers, using your existing accounts. It will allow you to connect and retrive your full electronic medical record and store it within Fasten.
+
+Run the following commands to download and start the Fasten docker container.
+
+```
+docker pull ghcr.io/fastenhealth/fasten-onprem:main
+docker run --rm -p 9090:8080 ghcr.io/fastenhealth/fasten-onprem:main
+```
+
+Next, open a browser to [http://localhost:9090](http://localhost:9090)
+
+At this point you'll be redirected to the login page.
+
+## Logging In
+
+Once you've been redirected to the login page, you'll need to create an account at [http://localhost:9090/web/auth/signup](http://localhost:9090/web/auth/signup).
+
+It can be as simple as
+
+- **Username:** `testuser`
+- **Password:** `testtest`
+
+Congrats! You're now logged in. You'll be redirected to the dashboard, which will be empty until you connect a healthcare provider.
+
+## Dashboard
+
+Once you login, you'll be taken to the dashboard.
+From here you can explore the data retrieved from the various healthcare providers.
+This page will intially be empty, see the next section - `Connecting a new Source` - for more info.
+
+## Connecting a new Source
+
+Before you can use Fasten, you'll need to connect a healthcare provider.
+
+If you're using the `main` flavor of Fasten, find a Source where you have an account, and login with your credentials.
+
+Congrats, you're all set! Fasten will now start syncing your medical records.

--- a/beta/main.md
+++ b/beta/main.md
@@ -8,7 +8,7 @@ nav_order: 1
 
 # Setting up Fasten to Use With Real Medical Data
 
-This version lets you connect to 27,000+ institutions using your existing accounts. It will enable you to connect and retrieve your full electronic medical record and store it within Fasten.
+These instructions will help you set up a version of Fasten that lets you connect to 27,000+ institutions using your existing accounts. It will enable you to connect and retrieve your full electronic medical record and store it within Fasten.
 
 Run the following commands to download and start the Fasten docker container.
 

--- a/beta/main.md
+++ b/beta/main.md
@@ -8,7 +8,7 @@ nav_order: 1
 
 # Setting up Fasten to Use With Real Medical Data
 
-This version allows you to connect to 650+ different Healthcare providers, using your existing accounts. It will allow you to connect and retrive your full electronic medical record and store it within Fasten.
+This version lets you connect to 27,000+ institutions using your existing accounts. It will enable you to connect and retrieve your full electronic medical record and store it within Fasten.
 
 Run the following commands to download and start the Fasten docker container.
 
@@ -17,15 +17,15 @@ docker pull ghcr.io/fastenhealth/fasten-onprem:main
 docker run --rm -p 9090:8080 ghcr.io/fastenhealth/fasten-onprem:main
 ```
 
-Next, open a browser to [http://localhost:9090](http://localhost:9090)
+To see if Fasten is running, open [http://localhost:9090](http://localhost:9090) in your browser.
 
-At this point you'll be redirected to the login page.
+Congrats, you've successfully started Fasten!
 
 ## Logging In
 
-Once you've been redirected to the login page, you'll need to create an account at [http://localhost:9090/web/auth/signup](http://localhost:9090/web/auth/signup).
+Once Fasten has started, you'll next need to create an account by clicking the [Create an Account button](http://localhost:9090/web/auth/signup) on the login screen. You'll be prompted to enter your name, a username, and a password.
 
-It can be as simple as
+It can be as simple as:
 
 - **Username:** `testuser`
 - **Password:** `testtest`
@@ -34,14 +34,14 @@ Congrats! You're now logged in. You'll be redirected to the dashboard, which wil
 
 ## Dashboard
 
-Once you login, you'll be taken to the dashboard.
-From here you can explore the data retrieved from the various healthcare providers.
-This page will intially be empty, see the next section - `Connecting a new Source` - for more info.
+Once you log in, you'll be taken to the dashboard.
+From here, you can explore the data retrieved from the various healthcare providers.
+This page will initially be empty; see the next section - `Connecting a new Source` - for more info.
 
 ## Connecting a new Source
 
 Before you can use Fasten, you'll need to connect a healthcare provider.
 
-If you're using the `main` flavor of Fasten, find a Source where you have an account, and login with your credentials.
+Click the `Add Source` button, scroll down to the `HEALTHCARE COMPANIES` section, and search for a patient portal to connect. Once you've selected a portal, follow the prompts and log in with your patient portal credentials. Once you've logged in, you'll be redirected back to the dashboard. Please note that syncing your medical records can take a while, so please be patient.
 
 Congrats, you're all set! Fasten will now start syncing your medical records.

--- a/beta/sandbox.md
+++ b/beta/sandbox.md
@@ -12,13 +12,13 @@ nav_order: 2
 
 > The instructions below are for the `sandbox` flavor of Fasten, which cannot connect to real patient portals. If you'd like to use Fasten with your real healthcare accounts, please follow the instructions [here](/beta/main.html).
 
-This version only allows you to connect to a handful of Healthcare providers, using Sandbox accounts that are meant for testing, and contain synthetic(fake) data to give you an idea what Fasten will look like, without requiring personal medical information.
+These instructions will help you set up a version of Fasten that only allows you to connect to a handful of Healthcare providers using Sandbox accounts that are meant for testing and contain synthetic(fake) data to give you an idea of what Fasten will look like without requiring personal medical information.
 
 Run the following commands to download and start the Fasten docker container.
 
 Next, open a browser to [http://localhost:9090](http://localhost:9090)
 
-At this point you'll be redirected to the login page.
+At this point, you'll be redirected to the login page.
 
 ## Logging In
 
@@ -29,19 +29,19 @@ It can be as simple as
 - **Username:** `testuser`
 - **Password:** `testtest`
 
-Congrats! You're now logged in. You'll be redirected to the dashboard, which will be empty until you connect a healthcare provider.
+Congrats! You're now logged in. You'll be redirected to the dashboard, which will be empty until you connect with a healthcare provider.
 
 ## Dashboard
 
 Once you login, you'll be taken to the dashboard.
-From here you can explore the data retrieved from the various healthcare providers.
-This page will intially be empty, see the next section - `Connecting a new Source` - for more info.
+From here, you can explore the data retrieved from the various healthcare providers.
+This page will initially be empty; see the next section - `Connecting a new Source` - for more info.
 
 ## Connecting a new Source
 
 Before you can use Fasten, you'll need to connect a healthcare provider.
 
-This version only allows you to connect to a handful of Healthcare providers, using Sandbox accounts that are meant for testing, and contain synthetic(fake) data to give you an idea what Fasten will look like, without requiring personal medical information.
+This version only allows you to connect to a handful of Healthcare providers using Sandbox accounts that are meant for testing and contain synthetic(fake) data to give you an idea of what Fasten will look like without requiring personal medical information.
 
 To do so, you'll need to use a Sandbox user and password from the table below. You should not (and cannot) use real credentials with the Sandbox version of Fasten.
 
@@ -63,9 +63,9 @@ To do so, you'll need to use a Sandbox user and password from the table below. Y
 | NextGen               | Username: `patientapitest` <br>Password: `Password1!`                      | [test accounts](https://www.nextgen.com/-/media/files/api/nge-patient-api-auth-guide.pdf)                                             |
 | VA Health             | Username: `va.api.user+idme.101@gmail.com` <br>Password: `Password1234!`   | [test accounts](https://github.com/department-of-veterans-affairs/vets-api-clients/blob/master/test_accounts/health_test_accounts.md) |
 
-Some providers (such as Cerner) may take a long time to sync, as their sandbox accounts have lots of test data. Please be patient.
+Some providers (such as Cerner) may take a long time to sync as their sandbox accounts have lots of test data. Please be patient.
 
 ## Testing Manual Bundle Upload
 
 If you'd like to test the manual bundle upload, you can use data provided by the [Synthea](https://synthetichealth.github.io/synthea-sample-data/downloads/synthea_sample_data_fhir_r4_sep2019.zip) project to test.
-Just extract the downloaded `zip` file, and upload one of the many `json` files.
+Just extract the downloaded `zip` file and upload one of the many `json` files.

--- a/beta/sandbox.md
+++ b/beta/sandbox.md
@@ -1,82 +1,16 @@
 ---
 layout: default
-title: Getting started
-description: "Getting started with self-hosting the Fasten Beta"
-nav_order: 1
+title: Setting up Fasten to Use Fake Test Data
+parent: Getting started
+description: "Setting up Fasten to use fake test data"
+nav_order: 2
 ---
 
-# Welcome to the Fasten Beta
-
-Welcome to the Fasten beta! This beta is provided with a couple of caveats:
-
-- Fasten is still partially closed-source (please see the Reddit discussion for more info)
-- The Beta version is only available as a Docker image (eventually we'll support other modes of distribution)
-- Fasten is still a work-in-progress (many buttons in the UI do not do anything)
-
-If you haven't already, please fill out this [Google Form](https://forms.gle/SNsYX9BNMXB6TuTw6)
-
-## Getting Started
-
-Below are instructions to get started with self hosting the Fasten Beta.
-
-Fasten comes in two flavors depending on whether you want to use it with your real medical records, or just test it out with fake data.
-
-{: .fs-6 .fw-300 }
-
-How would you like to use Fasten?
-
-[With real medical records](#setting-up-fasten-to-use-with-real-medical-data){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
-[With fake test data](#setting-up-fasten-to-use-fake-test-data-sandbox){: .btn .fs-5 .mb-4 .mb-md-0 }
-
----
-
-### Setting up Fasten to use with real medical data
-
-This version allows you to connect to 650+ different Healthcare providers, using your existing accounts. It will allow you to connect and retrive your full electronic medical record and store it within Fasten.
-
-Run the following commands to download and start the Fasten docker container.
-
-```
-docker pull ghcr.io/fastenhealth/fasten-onprem:main
-docker run --rm -p 9090:8080 ghcr.io/fastenhealth/fasten-onprem:main
-```
-
-Next, open a browser to [http://localhost:9090](http://localhost:9090)
-
-At this point you'll be redirected to the login page.
-
-#### Logging In
-
-Once you've been redirected to the login page, you'll need to create an account at [http://localhost:9090/web/auth/signup](http://localhost:9090/web/auth/signup).
-
-It can be as simple as
-
-- **Username:** `testuser`
-- **Password:** `testtest`
-
-Congrats! You're now logged in. You'll be redirected to the dashboard, which will be empty until you connect a healthcare provider.
-
-#### Dashboard
-
-Once you login, you'll be taken to the dashboard.
-From here you can explore the data retrieved from the various healthcare providers.
-This page will intially be empty, see the next section - `Connecting a new Source` - for more info.
-
-#### Connecting a new Source
-
-Before you can use Fasten, you'll need to connect a healthcare provider.
-
-If you're using the `main` flavor of Fasten, find a Source where you have an account, and login with your credentials.
-
-Congrats, you're all set! Fasten will now start syncing your medical records.
-
----
-
-### Setting up Fasten to use fake test data (Sandbox)
+# Setting up Fasten to Use Fake Test Data
 
 {: .warning }
 
-> The instructions below are for the `sandbox` flavor of Fasten, which cannot connect to real patient portals. If you'd like to use Fasten with your real healthcare accounts, please follow the instructions [here](#setting-up-fasten-main).
+> The instructions below are for the `sandbox` flavor of Fasten, which cannot connect to real patient portals. If you'd like to use Fasten with your real healthcare accounts, please follow the instructions [here](/beta/main.html).
 
 This version only allows you to connect to a handful of Healthcare providers, using Sandbox accounts that are meant for testing, and contain synthetic(fake) data to give you an idea what Fasten will look like, without requiring personal medical information.
 
@@ -86,7 +20,7 @@ Next, open a browser to [http://localhost:9090](http://localhost:9090)
 
 At this point you'll be redirected to the login page.
 
-#### Logging In
+## Logging In
 
 Once you've been redirected to the login page, you'll need to create an account at [http://localhost:9090/web/auth/signup](http://localhost:9090/web/auth/signup).
 
@@ -97,13 +31,13 @@ It can be as simple as
 
 Congrats! You're now logged in. You'll be redirected to the dashboard, which will be empty until you connect a healthcare provider.
 
-#### Dashboard
+## Dashboard
 
 Once you login, you'll be taken to the dashboard.
 From here you can explore the data retrieved from the various healthcare providers.
 This page will intially be empty, see the next section - `Connecting a new Source` - for more info.
 
-#### Connecting a new Source
+## Connecting a new Source
 
 Before you can use Fasten, you'll need to connect a healthcare provider.
 
@@ -131,18 +65,7 @@ To do so, you'll need to use a Sandbox user and password from the table below. Y
 
 Some providers (such as Cerner) may take a long time to sync, as their sandbox accounts have lots of test data. Please be patient.
 
-#### Testing Manual Bundle Upload
+## Testing Manual Bundle Upload
 
 If you'd like to test the manual bundle upload, you can use data provided by the [Synthea](https://synthetichealth.github.io/synthea-sample-data/downloads/synthea_sample_data_fhir_r4_sep2019.zip) project to test.
 Just extract the downloaded `zip` file, and upload one of the many `json` files.
-
----
-
-## Feedback
-
-If you notice any (non-obvious) issues with Fasten, please feel free to [open an issue on Github](https://github.com/fastenhealth/docs/issues).
-If you have any ideas or feedback for how to make Fasten better, please also consider [opening an issue on Github](https://github.com/fastenhealth/docs/issues).
-
-### Discord
-
-Please consider joining the [Fasten Discord](https://discord.gg/Bykz6BAN8p) as well. I'll be keeping an eye on it, and answering questions as they come up.

--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ nav_order: 0
 {: .fs-6 .fw-300 }
 Fasten is an open-source and self-hosted electronic medical record aggregator for individuals and families. Securely connect your healthcare providers together, creating a personal health record that never leaves your hands.
 
-[Get started now](/BETA.html){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Get started now](/beta/){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [View on GitHub](https://github.com/fastenhealth/fasten-onprem/){: .btn .fs-5 .mb-4 .mb-md-0 }
 
 ---
@@ -35,16 +35,14 @@ Recently I had a semi-serious medical issue, and I realized that my medical hist
 is a lot more complicated than I realized and distributed across the many healthcare providers I've used over the years.
 I wanted a single (private) location to store our medical records, and I just couldn't find any software that worked as I'd like:
 
-- self-hosted/offline - this is my medical history, I'm not willing to give it to some random multi-national corporation to data-mine and sell
-- It should aggregate my data from multiple healthcare providers (insurance companies, hospital networks, clinics, labs) across multiple industries (vision, dental, medical) -- all in one dashboard
-- automatic - it should pull my EMR (electronic medical record) directly from my insurance provider/clinic/hospital network - I dont want to scan/OCR physical documents (unless I have to)
-- open source - the code should be available for contributions & auditing
+- **Self-hosted** - this is my medical history, I'm not willing to give it to some random multi-national corporation to data-mine and sell
+- **All inclusive** - It should aggregate my data from multiple healthcare providers (insurance companies, hospital networks, clinics, labs) across multiple industries (vision, dental, medical) -- all in one dashboard
+- **Automatic** - It should pull my EMR (electronic medical record) directly from my insurance provider/clinic/hospital network - I dont want to scan/OCR physical documents (unless I have to)
+- **Open Source** - The code should be available for contributions & auditing
 
-So, I built it
+So, I built it.
 
 **Fasten is an open-source, self-hosted, personal/family electronic medical record aggregator, designed to integrate with 100,000's of insurances/hospitals/clinics**
-
-Here's a couple of screenshots that'll give you an idea of what it looks like:
 
 <p align="center">
   <a href="https://imgur.com/a/vfgojBD">
@@ -56,7 +54,7 @@ Here's a couple of screenshots that'll give you an idea of what it looks like:
 
 # Features
 
-It's pretty basic right now, but it's designed with a easily extensible core around a solid foundation:
+Fasten is designed with a solid foundation that is easily extensible:
 
 - Self-hosted
 - Designed for families, not Clinics (unlike OpenEMR and other popular EMR systems)

--- a/index.md
+++ b/index.md
@@ -1,10 +1,30 @@
 ---
 layout: default
-title: docs
+title: Welcome
+description: "What is Fasten?"
+nav_order: 0
 ---
-# docs
 
-> From my [fastenhealth/fasten-onprem](https://github.com/fastenhealth/fasten-onprem/)
+# What is Fasten?
+
+{: .fs-6 .fw-300 }
+Fasten is an open-source and self-hosted electronic medical record aggregator for individuals and families. Securely connect your healthcare providers together, creating a personal health record that never leaves your hands.
+
+[Get started now](/BETA.html){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[View on GitHub](https://github.com/fastenhealth/fasten-onprem/){: .btn .fs-5 .mb-4 .mb-md-0 }
+
+---
+
+{: .warning }
+
+> Fasten is a Work-in-Progress and can only communicate with a limited number of Healthcare Instutions (approx 25,000 at last count).
+> Please fill out this [Google Form](https://forms.gle/SNsYX9BNMXB6TuTw6) if you'd like to be kept up-to-date on Fasten
+>
+> To ensure Fasten's long-term sustainability, we're exploring some funding options. While we're still deciding a long-term monetization strategy, I'm kicking off with a crowdfunding/fundraising experiment for the first 500 users (including a surprise desktop app):
+>
+> - [Fasten Self-Hosted Lifetime License - **$200**](https://buy.stripe.com/fZe00deiUexS58Y4gg)
+>
+> Got questions or want to learn more about our fundraising experiment? [Click here to dive into the details & FAQs](https://docs.fastenhealth.com/FUNDRAISING.html)
 
 # Introduction
 
@@ -25,7 +45,6 @@ So, I built it
 **Fasten is an open-source, self-hosted, personal/family electronic medical record aggregator, designed to integrate with 100,000's of insurances/hospitals/clinics**
 
 Here's a couple of screenshots that'll give you an idea of what it looks like:
-
 
 <p align="center">
   <a href="https://imgur.com/a/vfgojBD">
@@ -52,4 +71,4 @@ It's pretty basic right now, but it's designed with a easily extensible core aro
 
 See [FAQs](./FAQs.md) for common questions (& answers) regarding Fasten
 
-See [FEATURES.md](./FEATURES.md) for a list of features that are planned for Fasten
+See [FEATURES](./FEATURES.md) for a list of features that are planned for Fasten


### PR DESCRIPTION
Opening a draft PR for proposed changes as part of the re-organization of the docs repo.

I think the first three pages to the docs site should be the following:
1) Welcome - Intro, explain what Fasten is, give user actionable next steps
2) What can Fasten do? - List and demo of current features
3) Getting started with Fasten - Installation instructions for the Fasten beta

Current tasks:
- [x] Improve welcome/index page with gentler onboarding and actionable buttons to guide users to next steps
- [ ] Add a "What can fasten do?" page with a quick overview of Fasten in its current state with videos/pictures.
- [x] Update the beta page to a "Getting started" page with guided installation instructions